### PR TITLE
change devDependencies to dependencies

### DIFF
--- a/packages/routes-gen/package.json
+++ b/packages/routes-gen/package.json
@@ -22,10 +22,12 @@
     "routes-gen": "dist/cli.js"
   },
   "dependencies": {
-    "@types/fs-extra": "^9.0.13",
-    "config": "*",
     "chalk": "^4.1.2",
     "fs-extra": "^10.0.0",
     "meow": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^9.0.13",
+    "config": "*"
   }
 }

--- a/packages/routes-gen/package.json
+++ b/packages/routes-gen/package.json
@@ -21,7 +21,7 @@
   "bin": {
     "routes-gen": "dist/cli.js"
   },
-  "devDependencies": {
+  "dependencies": {
     "@types/fs-extra": "^9.0.13",
     "config": "*",
     "chalk": "^4.1.2",


### PR DESCRIPTION
I had chalk v5 installed in my project, which raised an error because routes-gen needs v4, but v4 wasn't installed. The package needs to use dependencies and not devDependencies for its required packages to be installed with it