### PR TITLE
fix: change the empty object type {} to use TS Record utility type

### DIFF
--- a/packages/routes-gen/src/export-routes.ts
+++ b/packages/routes-gen/src/export-routes.ts
@@ -36,7 +36,7 @@ export const exportRoutes = ({
       return `    "${route.path}": ${
         params.length > 0
           ? `{ ${params.map((path) => `"${path}": string`).join(", ")} }`
-          : "{}"
+          : "Record<string, never>"
       };`;
     })
     .join("\n");


### PR DESCRIPTION
To use the more accurate type based on typescript/eslint's recommendations, The generated type when there's no param was changed to Record<string, never>

```
 Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead
```

https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/ban-types.md