### PR TITLE
fix: segment parsing

### DIFF
--- a/packages/routes-gen/src/route.test.ts
+++ b/packages/routes-gen/src/route.test.ts
@@ -1,16 +1,22 @@
 import { route } from "./route";
 
 it("supports optional params (issue 31)", () => {
-  expect(route("/reports/:type?/:id/", { id: "123" })).toEqual("/reports/123/");
-
-  expect(route("/reports/:type?/:id/", { id: "123", type: "annual" })).toEqual(
-    "/reports/annual/123/"
+  expect(route("/reports/:type?/:id", { id: "123" })).toEqual("/reports/123");
+  expect(route("/reports/:type?/:id?", { id: "123", type: "annual" })).toEqual(
+    "/reports/annual/123"
   );
 
-  expect(route("/reports/:id/:type?/", { id: "123" })).toEqual("/reports/123/");
 
-  expect(route("/reports/:id/:type?/", { id: "123", type: "annual" })).toEqual(
-    "/reports/123/annual/"
+  expect(route("/reports/:id/:type?", { id: "123" })).toEqual("/reports/123");
+  expect(route("/reports/:id/:type?", { id: "123", type: "annual" })).toEqual(
+    "/reports/123/annual"
+  );
+
+  expect(route("/categories?/:category?/products", {})).toEqual(
+    "/products"
+  );
+  expect(route("/categories?/:category?/products", { category: 'tees'})).toEqual(
+    "/categories/tees/products"
   );
 });
 


### PR DESCRIPTION
the routes function had a bug I found with optional segments that aren't parameterized.